### PR TITLE
Fix Python 3 issues

### DIFF
--- a/ligo/org/ecp.py
+++ b/ligo/org/ecp.py
@@ -292,7 +292,7 @@ def request(url, endpoint=IDP_ENDPOINTS['LIGO.ORG'], use_kerberos=None,
         # combine the login and password, base64 encode, and send
         # using the Authorization header
         base64string = base64.encodestring(
-            '%s:%s' % (login, password)).replace('\n', '')
+            ('%s:%s' % (login, password)).encode()).decode().replace('\n', '')
         request.add_header('Authorization', 'Basic %s' % base64string)
 
     response = opener.open(request)

--- a/ligo/org/ecp.py
+++ b/ligo/org/ecp.py
@@ -27,7 +27,7 @@ import time
 from tempfile import gettempdir
 from copy import deepcopy
 
-from six.moves import http_cookiejar
+from six.moves import http_cookiejar, input
 from six.moves.urllib import (request as urllib_request)
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.error import HTTPError
@@ -287,7 +287,7 @@ def request(url, endpoint=IDP_ENDPOINTS['LIGO.ORG'], use_kerberos=None,
     # get credentials for non-kerberos request
     if not use_kerberos:
         # prompt the user for a password
-        login = raw_input("Enter username for %s: ")
+        login = input("Enter username for %s: " % login_host)
         password = getpass.getpass("Enter password for login '%s': " % login)
         # combine the login and password, base64 encode, and send
         # using the Authorization header

--- a/ligo/org/kerberos.py
+++ b/ligo/org/kerberos.py
@@ -30,10 +30,7 @@ import sys
 import re
 from subprocess import (PIPE, Popen)
 
-try:
-    raw_input
-except NameError:
-    raw_input = input
+from six.moves import http_cookiejar, input
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __all__ = ['kinit', 'klist']
@@ -150,7 +147,7 @@ def kinit(username=None, password=None, realm=None, exe=None, keytab=None,
         realm = 'LIGO.ORG'
     if username is None:
         verbose = True
-        username = raw_input("Please provide username for the %s kerberos "
+        username = input("Please provide username for the %s kerberos "
                              "realm: " % realm)
     if not keytab and password is None:
         verbose = True


### PR DESCRIPTION
This patch fixes issues with the use of `raw_input`, which fails in Python 3. It also fixes a bug with the message printed to the user when prompting for the username in non-Kerberos mode.