### PR TITLE
Don't attempt to decode documents in ecp.request

### DIFF
--- a/ligo/org/ecp.py
+++ b/ligo/org/ecp.py
@@ -324,8 +324,4 @@ def request(url, endpoint=IDP_ENDPOINTS['LIGO.ORG'], use_kerberos=None,
 
     request = urllib_request.Request(url=url)
     response = opener.open(request)
-    out = response.read()
-
-    if isinstance(out, bytes):
-        return out.decode('utf-8')
-    return out
+    return response.read()


### PR DESCRIPTION
This PR fixes #4 by just returning whatever the response is from the HTTP request, rather than attempting to decode the object. This means that binary documents (e.g. PDF) can be written directly to local files with something along the lines of

```python
from ligo.org import request
with open('LIGO-T970130.pdf', 'wb') as f:
    f.write(request('https://dcc.ligo.org/DocDB/0000/T970130/001/T970130-v1.pdf'))
```

This might also mean that users have to do a minimal amount of extra post-processing for simple text data, compared to what they would do before.

[@SeanDS]