### PR TITLE
Updated klist to only return non-expired credentials

### DIFF
--- a/ligo/org/ecp.py
+++ b/ligo/org/ecp.py
@@ -235,11 +235,14 @@ def request(url, endpoint=IDP_ENDPOINTS['LIGO.ORG'], use_kerberos=None,
     # get kerberos credentials if available
     if use_kerberos is None:
         try:
-            klist()
+            creds = klist()
         except KerberosError:
             use_kerberos = False
         else:
-            use_kerberos = True
+            if creds:
+                use_kerberos = True
+            else:
+                use_kerberos = False
     if use_kerberos:
         opener.add_handler(HTTPNegotiateAuthHandler(
             service_principal='HTTP@%s' % login_host))

--- a/ligo/org/kerberos.py
+++ b/ligo/org/kerberos.py
@@ -28,6 +28,7 @@ import getpass
 import os
 import sys
 import re
+from datetime import datetime
 from subprocess import (PIPE, Popen)
 
 from six.moves import http_cookiejar, input
@@ -189,11 +190,14 @@ def klist():
     principals = []
     for line in out.splitlines():
         try:
-            principals.append(
-                KLIST_REGEX.match(line.decode('utf-8')
-                ).groupdict()['principal'])
+            cred = KLIST_REGEX.match(line.decode('utf-8')
+                ).groupdict()
         except AttributeError:
             continue
+        else:
+            expiry = datetime.strptime(cred['expiry'], '%d/%m/%Y %H:%M:%S')
+            if expiry > datetime.now():
+                principals.append(cred['principal'])
     return principals
 
 


### PR DESCRIPTION
This PR upgrades the `klist` method in `kerberos.py` to only return those principals found in the listing that have un-expired credentials.