### PR TITLE
ecp.py: accept all text mime types not just default (html)

### DIFF
--- a/ligo/org/ecp.py
+++ b/ligo/org/ecp.py
@@ -325,6 +325,7 @@ def request(url, endpoint=IDP_ENDPOINTS['LIGO.ORG'], use_kerberos=None,
 
     # -- actually send GET ----------------------
 
-    request = urllib_request.Request(url=url)
+    myheaders = {'Accept': 'text/*'}    # allow any text mime not only html
+    request = urllib_request.Request(url=url, headers=myheaders)
     response = opener.open(request)
     return response.read()


### PR DESCRIPTION
Small change to allow us to download any text mime like CSV files. Next change will probably be a kwarg so the  user can specify specific(eq applicaton/json) type or binary types (image/png)
