### PR TITLE
Added ecp-cookie-init implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
       - *install_build_dependencies
       - run:
           name: Install
-          command: python -m pip install --progress-bar=off .[doc]
+          command: python -m pip install --progress-bar=off .[docs]
       - run:
           name: Run sphinx-build
           command: pushd docs && python -m sphinx -M html . _build -E -W

--- a/docs/ecp-cookie-init.rst
+++ b/docs/ecp-cookie-init.rst
@@ -2,5 +2,5 @@ ecp-cookie-init
 ===============
 
 .. argparse::
-   :ref: ligo.org.tool.ecp_cookit_init.create_parser
-   :prog: ecp-cookit-init
+   :ref: ligo.org.tool.ecp_cookie_init.create_parser
+   :prog: ecp-cookie-init

--- a/docs/ecp-cookie-init.rst
+++ b/docs/ecp-cookie-init.rst
@@ -1,0 +1,6 @@
+ecp-cookie-init
+===============
+
+.. argparse::
+   :ref: ligo.org.tool.ecp_cookit_init.create_parser
+   :prog: ecp-cookit-init

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,8 +72,9 @@ Command-line scripts
 .. toctree::
    :maxdepth: 1
 
-   ligo-proxy-init
+   ecp-cookit-init
    ligo-curl
+   ligo-proxy-init
 
 |
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ Command-line scripts
 .. toctree::
    :maxdepth: 1
 
-   ecp-cookit-init
+   ecp-cookie-init
    ligo-curl
    ligo-proxy-init
 

--- a/ligo.org.spec
+++ b/ligo.org.spec
@@ -52,7 +52,8 @@ Requires: python2-%{pkgname} = %{version}
 Conflicts: ligo-proxy-utils
 %description -n ligo-proxy-utils2
 Command line utilities for LIGO.ORG SAML ECP authentication, including
-ligo-proxy-init and ligo-curl (a LIGO.ORG-aware curl alternative).
+ecp-proxy-init, ligo-proxy-init, and ligo-curl
+(a LIGO.ORG-aware curl alternative).
 
 # -- build ------------------
 
@@ -98,8 +99,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %files -n ligo-proxy-utils2
 %license LICENSE
-%{_bindir}/ligo-*
-%{_mandir}/man1/ligo-*.1*
+%{_bindir}/*
+%{_mandir}/man1/*.1*
 
 
 # -- changelog --------------

--- a/ligo/org/cookies.py
+++ b/ligo/org/cookies.py
@@ -19,6 +19,8 @@
 """Cookie handling for LIGO.ORG SAML ECP authentication
 """
 
+from __future__ import print_function
+
 import os
 import time
 import warnings

--- a/ligo/org/cookies.py
+++ b/ligo/org/cookies.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of LIGO.ORG.
+#
+# LIGO.ORG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LIGO.ORG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LIGO.ORG.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Cookie handling for LIGO.ORG SAML ECP authentication
+"""
+
+import os
+import time
+import warnings
+from pathlib import Path
+try:
+    from http.cookiejar import (LoadError, MozillaCookieJar)
+    from urllib.parse import urlparse
+except ImportError:  # python < 3
+    from cookielib import (LoadError, MozillaCookieJar)
+    from urlparse import urlparse
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def get_ecpcookie_path():
+    if os.name == "nt":
+        tmpdir = Path(r'%SYSTEMROOT%\Temp')
+        tmpname = "ecpcookie.{}".format(os.getlogin())
+    else:
+        tmpdir = Path("/tmp")
+        tmpname = "ecpcookie.u{}".format(os.getuid())
+    return tmpdir / tmpname
+
+
+COOKIE_FILE = get_ecpcookie_path()
+
+
+# -- cookie jar ---------------------------------------------------------------
+
+class ECPCookieJar(MozillaCookieJar):
+    """Custom cookie jar
+
+    Adapted from
+    https://wiki.shibboleth.net/confluence/download/attachments/4358416/ecp.py
+    """
+    def save(self, filename=None, ignore_discard=False, ignore_expires=False):
+        with open(filename, 'w') as f:
+            f.write(self.header)
+            for cookie in self:
+                if not ignore_discard and cookie.discard:
+                    continue
+                if not ignore_expires and cookie.is_expired(time.time()):
+                    continue
+                if cookie.expires is not None:
+                    expires = str(cookie.expires)
+                else:
+                    # change so that if a cookie does not have an expiration
+                    # date set it is saved with a '0' in that field instead
+                    # of a blank space so that the curl libraries can
+                    # read in and use the cookie
+                    expires = "0"
+                if cookie.value is None:
+                    # cookies.txt regards 'Set-Cookie: foo' as a cookie
+                    # with no name, whereas cookiejar regards it as a
+                    # cookie with no value.
+                    name = ""
+                    value = cookie.name
+                else:
+                    name = cookie.name
+                    value = cookie.value
+                print('\t'.join([
+                    cookie.domain,
+                    str(cookie.domain.startswith('.')).upper(),
+                    cookie.path,
+                    str(cookie.secure).upper(),
+                    expires,
+                    name,
+                    value,
+                ]), file=f)
+
+    def _really_load(self, f, filename, ignore_discard, ignore_expires):
+        out = super(ECPCookieJar, self)._really_load(
+            f,
+            filename,
+            ignore_discard,
+            ignore_expires,
+        )
+        for cookie in self:
+            if not cookie.expires:
+                cookie.expires = None
+        return out
+
+
+def has_session_cookies(jar, url):
+    """Returns `True` if this ``jar`` contains session cookies we can reuse
+
+    Parameters
+    ----------
+    jar : `http.cookiejar.CookieJar`
+        the cookie jar to check
+
+    url : `str`
+        the URL of the service that needs cookies
+
+    Returns
+    -------
+    can_reuse : `bool`
+        `True` if any cookie in the jar is a non-expiring ``shibsession``
+        cookie for the given same domain as ``url``
+    """
+    url = urlparse(url).netloc
+    for cookie in jar:
+        if (
+                cookie.name.startswith("_shibsession_") and
+                cookie.domain == url and
+                cookie.expires is None
+        ):
+            return True
+    return False
+
+
+def load_cookiejar(
+        cookiefile,
+        strict=True,
+        ignore_discard=True,
+        ignore_expires=True,
+):
+    """Load a cookie jar from a file
+
+    Parameters
+    ----------
+    cookiefile : `str`
+        path to cookie jar file
+
+    strict : `bool`, optional
+        if `True` (default), raise all exceptions as they occur,
+        if `False` just emit warnings
+
+    ignore_discard, ignore_expires : `bool`, optional
+        options to pass to :meth:`ECPCookieJar.load`, both default to
+        `True` in this usage.
+    """
+    cookiejar = ECPCookieJar()
+    try:
+        cookiejar.load(
+            str(cookiefile),
+            ignore_discard=ignore_discard,
+            ignore_expires=ignore_expires,
+        )
+    except (LoadError, OSError) as e:
+        if strict:
+            raise
+        warnings.warn('Caught error loading ECP cookie: %s' % str(e))
+    return cookiejar

--- a/ligo/org/ecp.py
+++ b/ligo/org/ecp.py
@@ -41,6 +41,8 @@ from .utils import (
     prompt_username_password,
 )
 
+LIGO_ENDPOINT_DOMAIN = "login.ligo.org"
+
 
 def get_xml_attribute(xdata, path, namespaces=None):
     if namespaces is None:

--- a/ligo/org/requests.py
+++ b/ligo/org/requests.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with LIGO.ORG.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import (print_function, absolute_import)
+from __future__ import absolute_import
 
 try:
     from urllib.request import Request

--- a/ligo/org/requests.py
+++ b/ligo/org/requests.py
@@ -18,84 +18,27 @@
 
 from __future__ import (print_function, absolute_import)
 
-import os
-import warnings
-import time
-from pathlib import Path
-from tempfile import gettempdir
 try:
-    from http.cookiejar import (LoadError, MozillaCookieJar)
-    from urllib.parse import urlparse
     from urllib.request import Request
 except ImportError:  # python < 3
-    from cookielib import (LoadError, MozillaCookieJar)
     from urllib2 import Request
-    from urlparse import urlparse
 
-from .ecp import authenticate
+from .cookies import (
+    COOKIE_FILE,
+    ECPCookieJar,
+    has_session_cookies,
+    load_cookiejar,
+)
+from .ecp import (LIGO_ENDPOINT_DOMAIN, authenticate)
 from .http import build_verified_opener
 from .kerberos import has_credential
-from .utils import get_idp_urls
-
-LIGO_ECP_ENDPOINT = "login.ligo.org"
-try:
-    COOKIE_FILE = Path(gettempdir()) / 'ecpcookie.u{}'.format(os.getuid())
-except AttributeError:  # no os.getuid means windows
-    COOKIE_FILE = Path(gettempdir()) / 'ecpcookie.{}'.format(os.getlogin())
-
-
-def _get_endpoint_url(institution, kerberos=False):
-    return get_idp_urls(institution)[int(kerberos)]
-
-
-# -- cookie jar ---------------------------------------------------------------
-
-class ECPCookieJar(MozillaCookieJar):
-    """Custom cookie jar
-
-    Adapted from
-    https://wiki.shibboleth.net/confluence/download/attachments/4358416/ecp.py
-    """
-    def save(self, filename=None, ignore_discard=False, ignore_expires=False):
-        with open(filename, 'w') as f:
-            f.write(self.header)
-            for cookie in self:
-                if not ignore_discard and cookie.discard:
-                    continue
-                if not ignore_expires and cookie.is_expired(time.time()):
-                    continue
-                if cookie.expires is not None:
-                    expires = str(cookie.expires)
-                else:
-                    # change so that if a cookie does not have an expiration
-                    # date set it is saved with a '0' in that field instead
-                    # of a blank space so that the curl libraries can
-                    # read in and use the cookie
-                    expires = "0"
-                if cookie.value is None:
-                    # cookies.txt regards 'Set-Cookie: foo' as a cookie
-                    # with no name, whereas cookiejar regards it as a
-                    # cookie with no value.
-                    name = ""
-                    value = cookie.name
-                else:
-                    name = cookie.name
-                    value = cookie.value
-                print('\t'.join([
-                    cookie.domain,
-                    str(cookie.domain.startswith('.')).upper(),
-                    cookie.path,
-                    str(cookie.secure).upper(),
-                    expires,
-                    name,
-                    value,
-                ]), file=f)
+from .utils import format_endpoint_url
 
 
 def request(
         url,
         username=None,
-        endpoint=LIGO_ECP_ENDPOINT,
+        endpoint=LIGO_ENDPOINT_DOMAIN,
         kerberos=None,
         cookiejar=None,
         cookiefile=COOKIE_FILE,
@@ -128,33 +71,12 @@ def request(
     response : `http.client.HTTPResponse`
         the response from the URL
     """
-    if endpoint is None:
-        endpoint = _get_endpoint_url("LIGO.*")
+    endpoint = format_endpoint_url(endpoint, kerberos=kerberos)
 
-    # -- initialise URL opener ------------------
-
-    # create a cookie jar and cookie handler (and read existing cookies)
+    # read existing cookies
     if cookiejar is None:
-        cookiejar = ECPCookieJar()
-        if Path(cookiefile or '').is_file():
-            try:
-                cookiejar.load(
-                    cookiefile,
-                    ignore_discard=True,
-                )
-            except LoadError as e:
-                warnings.warn('Caught error loading ECP cookie: %s' % str(e))
-
-    for cookie in cookiejar:
-        if (
-                cookie.name.startswith("_shibsession_") and
-                cookie.domain == urlparse(url).netloc and
-                cookie.expires is None
-        ):
-            reuse = True
-            break
-    else:
-        reuse = False
+        cookiejar = load_cookiejar(cookiefile, strict=False)
+    reuse = has_session_cookies(cookiejar, url)
 
     # -- authenticate ---------------------------
 
@@ -175,6 +97,7 @@ def request(
             cookiejar.save(
                 cookiefile,
                 ignore_discard=store_session_cookies,
+                ignore_expires=store_session_cookies,
             )
 
     # -- actually send GET ----------------------

--- a/ligo/org/tests/test_utils.py
+++ b/ligo/org/tests/test_utils.py
@@ -44,11 +44,22 @@ RAW_INSTITUTION_LIST = [
     return_value=RAW_INSTITUTION_LIST,
 )
 def test_get_idps(urlopen):
-    assert ligodotorg_utils.get_idps("something") == {
+    assert ligodotorg_utils.get_idps("something", extras=False) == {
         "Institution 1": "https://inst1.test",
         "Institution 2": "https://inst2.test",
     }
     assert urlopen.called_with("something")
+
+
+@mock.patch(
+    "{}.urlopen".format(urlreqmodname),
+    return_value=RAW_INSTITUTION_LIST,
+)
+def test_get_idps_extras(_):
+    idps = ligodotorg_utils.get_idps("something", extras=True)
+    assert idps["Cardiff University"] == (
+        "https://idp.cf.ac.uk/idp/profile/SAML2/SOAP/ECP"
+    )
 
 
 @mock.patch(

--- a/ligo/org/tool/utils.py
+++ b/ligo/org/tool/utils.py
@@ -19,6 +19,8 @@
 """Common utilities for tools
 """
 
+from __future__ import print_function
+
 import argparse
 import sys
 

--- a/ligo/org/tool/utils.py
+++ b/ligo/org/tool/utils.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of LIGO.ORG.
+#
+# LIGO.ORG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LIGO.ORG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LIGO.ORG.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Common utilities for tools
+"""
+
+import argparse
+import sys
+
+from ..cookies import (
+    LoadError,
+    has_session_cookies,
+    load_cookiejar,
+)
+from ..utils import get_idps
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+# -- argparse helpers ---------------------------
+
+class HelpFormatter(
+    argparse.ArgumentDefaultsHelpFormatter,
+    argparse.RawDescriptionHelpFormatter,
+):
+    pass
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *args, **kwargs):
+        add_helpers = kwargs.pop("add_helpers", True)
+        version = kwargs.pop("version", None)
+
+        kwargs.setdefault("formatter_class", HelpFormatter)
+        kwargs.setdefault("add_help", not add_helpers)
+        super(ArgumentParser, self).__init__(*args, **kwargs)
+
+        self._positionals.title = "Positional arguments"
+        self._optionals.title = "Optional arguments"
+
+        # add helper commands group
+        if add_helpers:
+            helpers = self.add_argument_group("Helper arguments")
+            helpers.add_argument(
+                "-h",
+                "--help",
+                action="help",
+                default=argparse.SUPPRESS,
+                help="show this help message and exit",
+            )
+            helpers.add_argument(
+                "-l",
+                "--list-idps",
+                action=ListIdpsAction,
+            )
+            if version is not None:
+                helpers.add_argument(
+                    "-V",
+                    "--version",
+                    action="version",
+                    version=version,
+                )
+
+
+class ListIdpsAction(argparse.Action):
+    def __init__(
+            self,
+            option_strings,
+            dest=argparse.SUPPRESS,
+            default=argparse.SUPPRESS,
+            help="show IdP names and URLs and exit",
+    ):
+        super(ListIdpsAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs=0,
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        idps = get_idps(extras=True)
+        formatter = parser._get_formatter()
+        fmt = "%-{}s : %s".format(max(map(len, idps)))
+        for pair in sorted(idps.items(), key=lambda x: x[0]):
+            formatter.add_text(fmt % pair)
+        parser._print_message(formatter.format_help(), sys.stdout)
+        parser.exit()
+
+
+# -- miscellaneous ------------------------------
+
+def reuse_cookiefile(cookiefile, url, verbose=False):
+    """Load cookies from a cookiefile and determine if they can be reused
+
+    Parameters
+    ----------
+    cookiefile : `str`
+        the path to the cookie file
+
+    url : `str`
+        the URL of the service being accessed with cookies
+
+    verbose : `bool`, optional
+        if `True`, print verbose output
+
+    Returns
+    -------
+    cookiejar : `ligo.org.cookies.ECPCookieJar`, `NoneType`
+        the cookie jar (if the cookie file was read correctly), otherwise
+        `None`
+    reuse : `bool`
+        `True` if the cookies in the jar can be reused to access the given
+        service URL, otherwise `False`
+    """
+    if verbose:
+        print("Validating existing cookies...", end=" ")
+    try:
+        cookiejar = load_cookiejar(cookiefile, strict=True)
+    except LoadError:
+        cookiejar = None
+        reuse = False
+        if verbose:
+            print("failed to load cookie file")
+    else:
+        reuse = has_session_cookies(cookiejar, url)
+        if verbose and reuse:
+            print("OK")
+        elif verbose:
+            print("cannot reuse, need new cookies")
+    return cookiejar, reuse

--- a/ligo/org/x509.py
+++ b/ligo/org/x509.py
@@ -25,6 +25,7 @@ import string
 import struct
 import tempfile
 import time
+from pathlib import Path
 try:
     from urllib import parse as urllib_parse
     from urllib import request as urllib_request
@@ -60,6 +61,24 @@ def _random_string(length, outof=string.ascii_lowercase+string.digits):
 
 
 # -- X.509 generator ----------------------------------------------------------
+
+def get_x509_proxy_path():
+    """Returns the default path for the X.509 certificate file
+
+    Returns
+    -------
+    path : `pathlib.Path`
+    """
+    if os.getenv("X509_USER_PROXY"):
+        return Path(os.environ["X509_USER_PROXY"])
+    if os.name == "nt":
+        tmpdir = Path(r'%SYSTEMROOT%\Temp')
+        tmpname = "x509up_{}".format(os.getlogin())
+    else:
+        tmpdir = Path("/tmp")
+        tmpname = "x509up_u{}".format(os.getuid())
+    return tmpdir / tmpname
+
 
 def get_cert(
         endpoint,

--- a/setup.py
+++ b/setup.py
@@ -100,8 +100,9 @@ setup(
     namespace_packages=['ligo'],
     entry_points={
         "console_scripts": [
-            "ligo-proxy-init=ligo.org.tool.ligo_proxy_init:main",
+            "ecp-cookie-init=ligo.org.tool.ecp_cookie_init:main",
             "ligo-curl=ligo.org.tool.ligo_curl:main",
+            "ligo-proxy-init=ligo.org.tool.ligo_proxy_init:main",
         ],
     },
     # dependencies


### PR DESCRIPTION
This PR implements a new version of `ecp-cookie-init`, which authenticates and stores shib session cookies on the users machine.
In implementing this, the following library changes were made:

- new `ligo.org.cookies` module to provide generic cookie utilities
- added global variable in `ligo.org.ecp` for default LIGO endpoint domain name
- new `ligo.org.tool.utils` module to provide common command-line script utilities

cc @paulhopkins